### PR TITLE
Increase subprocessed test time out to 10 seconds

### DIFF
--- a/qtrio/_tests/test_core.py
+++ b/qtrio/_tests/test_core.py
@@ -25,7 +25,7 @@ def test_reenter_event_triggers_in_main_thread(qapp):
     assert result == [threading.get_ident()]
 
 
-timeout = 3
+timeout = 10
 
 
 def test_run_returns_value(testdir):


### PR DESCRIPTION
It seems like there have been some sporadic timeouts.