### PR TITLE
Provide more control over reentry event type registration

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -39,6 +39,8 @@ python setup.py sdist --formats=zip
 INSTALL_ARTIFACT=$(ls dist/*.zip)
 python -m pip install ${INSTALL_ARTIFACT}${INSTALL_EXTRAS}
 
+python -m pip install --upgrade https://github.com/altendky/sphinx-qt-documentation/archive/7-altendky-handle_qevent_type_enumeration.zip
+
 python -m pip list
 python -m pip freeze
 

--- a/ci.sh
+++ b/ci.sh
@@ -39,8 +39,6 @@ python setup.py sdist --formats=zip
 INSTALL_ARTIFACT=$(ls dist/*.zip)
 python -m pip install ${INSTALL_ARTIFACT}${INSTALL_EXTRAS}
 
-python -m pip install --upgrade https://github.com/altendky/sphinx-qt-documentation/archive/7-altendky-handle_qevent_type_enumeration.zip
-
 python -m pip list
 python -m pip freeze
 

--- a/docs/source/core.rst
+++ b/docs/source/core.rst
@@ -30,3 +30,15 @@ their errors on the floor they will be run inside a nursery.
 
 .. autofunction:: qtrio.open_emissions_nursery
 .. autoclass:: qtrio.EmissionsNursery
+
+
+Reentry Events
+--------------
+
+Generally you should not need to use these functions.  If you want to either have
+control over when the Qt event type is registered, what value it gets, or handle any
+exceptions raise then you may like to call these directly.
+
+.. autofunction:: qtrio.register_event_type
+.. autofunction:: qtrio.register_requested_event_type
+.. autofunction:: qtrio.registered_event_type

--- a/docs/source/core.rst
+++ b/docs/source/core.rst
@@ -37,7 +37,7 @@ Reentry Events
 
 Generally you should not need to use these functions.  If you want to either have
 control over when the Qt event type is registered, what value it gets, or handle any
-exceptions raise then you may like to call these directly.
+exceptions raised then you may like to call these directly.
 
 .. autofunction:: qtrio.register_event_type
 .. autofunction:: qtrio.register_requested_event_type

--- a/docs/source/exceptions.rst
+++ b/docs/source/exceptions.rst
@@ -3,5 +3,8 @@ Exceptions
 
 .. autoclass:: qtrio.QTrioException
 .. autoclass:: qtrio.NoOutcomesError
-.. autoclass:: qtrio.RegisterEventTypeError
+.. autoclass:: qtrio.EventTypeRegistrationError
+.. autoclass:: qtrio.EventTypeRegistrationFailedError
+.. autoclass:: qtrio.RequestedEventTypeUnavailableError
+.. autoclass:: qtrio.EventTypeAlreadyRegisteredError
 .. autoclass:: qtrio.ReturnCodeError

--- a/newsfragments/16.feature.rst
+++ b/newsfragments/16.feature.rst
@@ -1,2 +1,2 @@
-Provide more control over the reentry event type via :func:`register_event_type`,
-:func:`register_requested_event_type`, and :func:`registered_event_type`.
+Provide more control over the reentry event type via :func:`qtrio.register_event_type`,
+:func:`qtrio.register_requested_event_type`, and :func:`qtrio.registered_event_type`.

--- a/newsfragments/16.feature.rst
+++ b/newsfragments/16.feature.rst
@@ -1,0 +1,2 @@
+Provide more control over the reentry event type via :func:`register_event_type`,
+:func:`register_requested_event_type`, and :func:`registered_event_type`.

--- a/qtrio/__init__.py
+++ b/qtrio/__init__.py
@@ -5,7 +5,10 @@ from ._version import __version__
 from ._exceptions import (
     QTrioException,
     NoOutcomesError,
-    RegisterEventTypeError,
+    EventTypeRegistrationError,
+    EventTypeRegistrationFailedError,
+    RequestedEventTypeUnavailableError,
+    EventTypeAlreadyRegisteredError,
     ReturnCodeError,
     RunnerTimedOutError,
 )
@@ -19,6 +22,9 @@ from ._core import (
     Outcomes,
     run,
     Runner,
+    registered_event_type,
+    register_event_type,
+    register_requested_event_type,
 )
 
 from ._pytest import host

--- a/qtrio/_core.py
+++ b/qtrio/_core.py
@@ -60,7 +60,9 @@ def register_event_type():
     _reenter_event_type = QtCore.QEvent.Type(event_hint)
 
 
-def register_requested_event_type(requested_value: int):
+def register_requested_event_type(
+    requested_value: typing.Union[int, QtCore.QEvent.Type]
+):
     """Register the requested Qt event type for use by Trio to reenter into the Qt event
     loop.  Raises :class:`qtrio.EventTypeAlreadyRegisteredError` if an event type
     has already been registered.  Raises :class:`qtrio.EventTypeRegistrationFailedError`

--- a/qtrio/_core.py
+++ b/qtrio/_core.py
@@ -35,6 +35,9 @@ _reenter_event_type: typing.Optional[QtCore.QEvent.Type] = None
 
 
 def registered_event_type() -> typing.Optional[QtCore.QEvent.Type]:
+    """Get the registered event type.  :py:obj:`None` if no event type has been
+    registered.
+    """
     return _reenter_event_type
 
 

--- a/qtrio/_core.py
+++ b/qtrio/_core.py
@@ -68,7 +68,11 @@ def register_requested_event_type(
     has already been registered.  Raises :class:`qtrio.EventTypeRegistrationFailedError`
     if a type was not able to be registered.  Raises
     :class:`qtrio.RequestedEventTypeUnavailableError` if the type returned by Qt does
-    not match the requested type."""
+    not match the requested type.
+
+    Arguments:
+        requested_value: The value to ask Qt to use for the event type being registered.
+    """
     global _reenter_event_type
 
     if _reenter_event_type is not None:

--- a/qtrio/_exceptions.py
+++ b/qtrio/_exceptions.py
@@ -14,10 +14,38 @@ class NoOutcomesError(QTrioException):
     pass
 
 
-class RegisterEventTypeError(QTrioException):
+class EventTypeRegistrationError(QTrioException):
+    """Base class for various event type registration exceptions to inherit from."""
+
+
+class EventTypeRegistrationFailedError(EventTypeRegistrationError):
     """Raised if the attempt to register a new event type fails."""
 
-    pass
+    def __init__(self):
+        super().__init__(
+            "Failed to register the event hint, either no available hints remain or the"
+            + " program is shutting down."
+        )
+
+
+class RequestedEventTypeUnavailableError(EventTypeRegistrationError):
+    """Raised if the requested event type is unavailable."""
+
+    def __init__(self, requested_type, returned_type):
+        super().__init__(
+            f"Failed acquire the requested type ({requested_type}), got back"
+            + f" ({returned_type}) instead."
+        )
+
+
+class EventTypeAlreadyRegisteredError(EventTypeRegistrationError):
+    """Raised when a request is made to register an event type but a type has already
+    been registered previously."""
+
+    def __init__(self):
+        super().__init__(
+            "An event type has already been registered, this must only happen once."
+        )
 
 
 class ReturnCodeError(QTrioException):

--- a/qtrio/_tests/test_core.py
+++ b/qtrio/_tests/test_core.py
@@ -277,8 +277,9 @@ def test_done_callback_gets_outcomes(testdir):
 
 
 def test_out_of_hints_raises(testdir):
-    """If there are no available Qt event types remaining RegisterEventTypeError is
-    raised when requesting a type without any specific requested value.
+    """If there are no available Qt event types remaining
+    EventTypeRegistrationFailedError is raised when requesting a type without any
+    specific requested value.
     """
     test_file = r"""
     import pytest
@@ -301,8 +302,9 @@ def test_out_of_hints_raises(testdir):
 
 
 def test_out_of_hints_raises_for_requested(testdir):
-    """If there are no available Qt event types remaining RegisterEventTypeError is
-    raised when requesting a type with a specific requested value.
+    """If there are no available Qt event types remaining
+    EventTypeRegistrationFailedError is raised when requesting a type with a specific
+    requested value.
     """
     test_file = r"""
     import pytest

--- a/qtrio/_tests/test_core.py
+++ b/qtrio/_tests/test_core.py
@@ -385,6 +385,25 @@ def test_registering_event_type_when_already_registered(testdir):
     result.assert_outcomes(passed=1)
 
 
+def test_registering_requested_event_type_when_already_registered(testdir):
+    """Requesting an available event type succeeds."""
+    test_file = r"""
+    import pytest
+    import qtrio
+
+
+    def test():
+        qtrio.register_event_type()
+
+        with pytest.raises(qtrio.EventTypeAlreadyRegisteredError):
+            qtrio.register_requested_event_type(qtrio.registered_event_type())
+    """
+    testdir.makepyfile(test_file)
+
+    result = testdir.runpytest_subprocess(timeout=timeout)
+    result.assert_outcomes(passed=1)
+
+
 def test_wait_signal_waits(testdir):
     """wait_signal() waits for the signal.
     """

--- a/qtrio/_tests/test_core.py
+++ b/qtrio/_tests/test_core.py
@@ -357,8 +357,27 @@ def test_requesting_available_event_type_succeeds(testdir):
 
     def test():
         qtrio.register_requested_event_type(QtCore.QEvent.User)
-        
+
         assert qtrio.registered_event_type() == QtCore.QEvent.User
+    """
+    testdir.makepyfile(test_file)
+
+    result = testdir.runpytest_subprocess(timeout=timeout)
+    result.assert_outcomes(passed=1)
+
+
+def test_registering_event_type_when_already_registered(testdir):
+    """Requesting an available event type succeeds."""
+    test_file = r"""
+    import pytest
+    import qtrio
+
+
+    def test():
+        qtrio.register_event_type()
+
+        with pytest.raises(qtrio.EventTypeAlreadyRegisteredError):
+            qtrio.register_event_type()
     """
     testdir.makepyfile(test_file)
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         "docs": [
             "sphinx >= 1.7.0",
             "sphinx-autodoc-typehints",
-            "sphinx-qt-documentation",
+            "sphinx-qt-documentation>=0.3",
             "sphinx_rtd_theme",
             "sphinxcontrib-trio",
         ],


### PR DESCRIPTION
Fixes #16.

Draft for:
- [x] update requirements to specify new sphinx-qt-documentation version
- [x] remove forced zip installation of sphinx-qt-documentation

Stalled on:
- [x] https://github.com/Czaki/sphinx-qt-documentation/issues/7
  - Released in v0.3 https://pypi.org/project/sphinx-qt-documentation/0.3/