### PR TITLE
Correct CI job name to Linux, not Ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,8 +113,8 @@ jobs:
           # TODO: https://github.com/pytest-dev/pytest/issues/7623
           PYTHONIOENCODING: 'utf-8'
 
-  Ubuntu:
-    name: 'Ubuntu (${{ matrix.python }}, ${{ matrix.qt_library }})'
+  Linux:
+    name: 'Linux (${{ matrix.python }}, ${{ matrix.qt_library }})'
     timeout-minutes: 10
     runs-on: 'ubuntu-latest'
     container: 'docker://python:${{ matrix.python }}-buster'
@@ -138,7 +138,7 @@ jobs:
         run: ./ci.sh
         env:
           # Should match 'name:' up above
-          JOB_NAME: 'Ubuntu (${{ matrix.python }}, ${{ matrix.qt_library }})'
+          JOB_NAME: 'Linux (${{ matrix.python }}, ${{ matrix.qt_library }})'
           INSTALL_EXTRAS: '[${{ matrix.qt_library }},p_tests]'
 
   macOS:
@@ -171,7 +171,7 @@ jobs:
       - Builds
       - Checks
       - Windows
-      - Ubuntu
+      - Linux
       - macOS
     steps:
       - name: This


### PR DESCRIPTION
The GitHub Actions host is Ubuntu but the docker guest is Debian.