### PR TITLE
update development testing doc extras

### DIFF
--- a/docs/source/development/testing.rst
+++ b/docs/source/development/testing.rst
@@ -15,7 +15,7 @@ You can run ``pytest``, ``black``, and ``sphinx`` directly from your own install
 
    python -m venv testvenv
    testvenv/bin/pip install --upgrade pip setuptools wheel
-   testvenv/bin/pip install --editable .[pyside2,checks,docs,tests]
+   testvenv/bin/pip install --editable .[pyside2,p_checks,p_docs,p_tests]
    testvenv/bin/pytest --pyargs qtrio
 
 The CI test script, ``ci.sh``, in the project root will run ``pytest`` with ``coverage``
@@ -51,7 +51,7 @@ The documentation can be built with ``sphinx``.
 
    python -m venv testvenv
    testvenv/bin/pip install --upgrade pip setuptools wheel
-   testvenv/bin/pip install --editable .[pyside2,docs]
+   testvenv/bin/pip install --editable .[pyside2,p_docs]
    source testenv/bin/activate
    cd docs/
    make html --always-make


### PR DESCRIPTION
When following the development testing documentation, I noticed that the extras in a couple commands did not work properly. Update docs to match `setup.cfg` extras.