### PR TITLE
update example dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -65,9 +65,9 @@ cli =
     click ~= 7.0
 examples =
     %(cli)s
-    httpcore ~= 0.12.0
-    httpx ~= 0.16.0
-    hyperlink ~= 20.0.0
+    httpcore ~= 0.13.6
+    httpx ~= 0.18.2
+    hyperlink ~= 21.0.0
 testing =
     %(s_pytest_trio)s
 p_checks =

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,6 +66,9 @@ cli =
 examples =
     %(cli)s
     httpcore ~= 0.13.6
+    # >= 0.18.2 for https://github.com/encode/httpx/commit/b43af721cd7804214396b5511e4f68d144a9b6a6
+    #     Relates to flaky test failing with:
+    #         ResourceWarning: Async generator 'httpx._auth.Auth.async_auth_flow' was garbage collected before it had been exhausted. Surround its use in 'async with aclosing(...):' to ensure that it gets cleaned up as soon as you're done using it.
     httpx ~= 0.18.2
     hyperlink ~= 21.0.0
 testing =


### PR DESCRIPTION
Address flaky tests.

https://github.com/altendky/qtrio/runs/2855606009?check_suite_focus=true#step:4:861
```
E               pytest.PytestUnraisableExceptionWarning: Exception ignored in: <async_generator object Auth.async_auth_flow at 0x000001C4BA7A25E0>
E               
E               Traceback (most recent call last):
E                 File "c:\hostedtoolcache\windows\python\3.8.10\x64\lib\site-packages\trio\_core\_asyncgens.py", line 79, in finalizer
E                   warnings.warn(
E               ResourceWarning: Async generator 'httpx._auth.Auth.async_auth_flow' was garbage collected before it had been exhausted. Surround its use in 'async with aclosing(...):' to ensure that it gets cleaned up as soon as you're done using it.
```

httpx addressed this in 0.18.2 via https://github.com/encode/httpx/commit/b43af721cd7804214396b5511e4f68d144a9b6a6?w=1#diff-905594f34b3a0c59f2fa149877415115c7362bd9652f7327186bf21c199f564fR927.