### PR TITLE
return True from Reenter.event()

### DIFF
--- a/qtrio/_core.py
+++ b/qtrio/_core.py
@@ -110,7 +110,7 @@ class Reenter(QtCore.QObject):
 
         reenter_event = typing.cast(Reenter, event)
         reenter_event.fn()
-        return False
+        return True
 
 
 async def wait_signal(signal: qtrio._util.SignalInstance) -> typing.Tuple[object, ...]:

--- a/qtrio/_tests/test_core.py
+++ b/qtrio/_tests/test_core.py
@@ -73,6 +73,32 @@ def test_reenter_event_raises_if_type_not_registered(testdir):
     result.assert_outcomes(passed=1)
 
 
+def test_reenter_event_writes_to_stderr_for_exception(capsys, testdir):
+    test_file = r"""
+    import pytest
+
+    from qts import QtCore
+    import qtrio
+    import qtrio.qt
+
+    qapp = QtCore.QCoreApplication([])
+    qtrio.register_event_type()
+    reenter = qtrio.qt.Reenter()
+    event = qtrio.qt.ReenterEvent(fn=32)
+    qapp.postEvent(reenter, event)
+    qapp.processEvents()
+    """
+    test_path = testdir.makepyfile(test_file)
+
+    result = testdir.runpython(test_path)
+    result.stderr.re_match_lines(
+        lines2=[
+            r"^TypeError: 'int' object is not callable$",
+            r"^qtrio._exceptions.InternalError: Exception while handling a reenter event$",
+        ],
+    )
+
+
 def test_run_returns_value(testdir):
     """:func:`qtrio.run()` returns the result of the passed async function."""
 

--- a/qtrio/_tests/test_core.py
+++ b/qtrio/_tests/test_core.py
@@ -75,11 +75,11 @@ def test_reenter_event_raises_if_type_not_registered(testdir):
 
 def test_reenter_event_writes_to_stderr_for_exception(capsys, testdir):
     test_file = r"""
-    import pytest
-
     from qts import QtCore
+
     import qtrio
     import qtrio.qt
+
 
     qapp = QtCore.QCoreApplication([])
     qtrio.register_event_type()

--- a/qtrio/_tests/test_core.py
+++ b/qtrio/_tests/test_core.py
@@ -94,7 +94,7 @@ def test_reenter_event_writes_to_stderr_for_exception(capsys, testdir):
     result.stderr.re_match_lines(
         lines2=[
             r"^TypeError: 'int' object is not callable$",
-            r"^qtrio._exceptions.InternalError: Exception while handling a reenter event$",
+            r"^qtrio\._exceptions\.InternalError: Exception while handling a reenter event$",
         ],
     )
 

--- a/qtrio/qt.py
+++ b/qtrio/qt.py
@@ -1,3 +1,5 @@
+import sys
+import traceback
 import typing
 
 from qts import QtCore
@@ -26,6 +28,9 @@ class Reenter(QtCore.QObject):
     def event(self, event: QtCore.QEvent) -> bool:
         """Qt calls this when the object receives an event."""
 
-        reenter_event = typing.cast(Reenter, event)
-        reenter_event.fn()
-        return True
+        try:
+            reenter_event = typing.cast(Reenter, event)
+            reenter_event.fn()
+            return True
+        except Exception as e:
+            raise qtrio.InternalError("Exception while handling a reenter event") from e

--- a/qtrio/qt.py
+++ b/qtrio/qt.py
@@ -1,5 +1,3 @@
-import sys
-import traceback
 import typing
 
 from qts import QtCore


### PR DESCRIPTION
Maybe?  https://doc.qt.io/qt-5/qobject.html#event reads like it.  Maybe catch exceptions and return `False` in those cases?  Brought up in https://github.com/altendky/qtrio/pull/251#pullrequestreview-701270779.  Probably came from:


https://gist.github.com/njsmith/d996e80b700a339e0623f97f48bcf0cb#file-trio-qt-demo-py-L60-L63
```python
class Reenter(QtCore.QObject):
    def event(self, event):
        event.fn()
        return False
```

Mostly this only relates to weird corner cases where we've messed up something basic or someone is playing some games maybe so any improvement is primarily about improving diagnostic behavior.