### PR TITLE
Update `trio` to `0.17` & `trio-typing` to `0.8.0`

### DIFF
--- a/qtrio/_core.py
+++ b/qtrio/_core.py
@@ -652,7 +652,7 @@ class Runner:
             args,
             run_sync_soon_threadsafe=self.run_sync_soon_threadsafe,
             done_callback=self.trio_done,
-            clock=self.clock,  # type: ignore[arg-type]
+            clock=self.clock,
             instruments=self.instruments,
         )
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,9 +44,9 @@ install_requires=
     decorator
     outcome
     qts ~= 0.3.0
-    # trio >= 0.16 for guest mode
-    trio >= 0.16
-    trio-typing ~= 0.7.0
+    # trio >= 0.17 for guest mode
+    trio >= 0.17
+    trio-typing ~= 0.8.0
     # python_version < '3.8' for `Protocol`
     typing-extensions; python_version < '3.8'
 packages = find:


### PR DESCRIPTION
Hello, I would like to update the version of `trio` & relax the version of `trio-typing`.

I'm working on a project where we use `qtrio`, `trio` & `trio-typing` and we would like to update `trio` & `trio-typing`.
But we're stuck being with `qtrio` requirement for `trio-typing`.

So I propose this pull-request, I've tested the change on the said project and it work, 
I've also executed the following command on `qtrio`

```shell
python3 -m venv testvenv
source testvenv/bin/activate
INSTALL_EXTRAS=[PyQt5,p_tests] ./ci.sh
INSTALL_EXTRAS=[PyQt5,p_checks,p_docs] CHECK_TYPE_HINTS=1 ./ci.sh
```