### PR TITLE
Fix pytest 8.4 exception group assertions and CI flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
           INSTALL_EXTRAS: '[${{ matrix.qt_library }},p-tests]'
           # TODO: https://github.com/pytest-dev/pytest/issues/7623
           PYTHONIOENCODING: 'utf-8'
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v7
         if: always()
         with:
           # Should match 'name:' up above
@@ -169,7 +169,7 @@ jobs:
         run: ./ci.sh
         env:
           INSTALL_EXTRAS: '[${{ matrix.qt_library }},p-tests]'
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v7
         if: always()
         with:
           # Should match 'name:' up above
@@ -201,7 +201,7 @@ jobs:
         run: ./ci.sh
         env:
           INSTALL_EXTRAS: '[${{ matrix.qt_library }},p-tests]'
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v7
         if: always()
         with:
           # Should match 'name:' up above

--- a/qtrio/_tests/examples/test_crossingpaths.py
+++ b/qtrio/_tests/examples/test_crossingpaths.py
@@ -11,7 +11,7 @@ import qtrio.examples.crossingpaths
 async def test_main(
     qtbot: pytestqt.qtbot.QtBot,
     optional_hold_event: typing.Optional[trio.Event],
-    autojump_clock: qtrio.testing.MockClock,
+    autojump_clock: trio.testing.MockClock,
 ) -> None:
     message = "test world"
 

--- a/qtrio/_tests/examples/test_crossingpaths.py
+++ b/qtrio/_tests/examples/test_crossingpaths.py
@@ -9,7 +9,9 @@ import qtrio.examples.crossingpaths
 
 
 async def test_main(
-    qtbot: pytestqt.qtbot.QtBot, optional_hold_event: typing.Optional[trio.Event]
+    qtbot: pytestqt.qtbot.QtBot,
+    optional_hold_event: typing.Optional[trio.Event],
+    autojump_clock: qtrio.testing.MockClock,
 ) -> None:
     message = "test world"
 

--- a/qtrio/_tests/examples/test_download.py
+++ b/qtrio/_tests/examples/test_download.py
@@ -9,7 +9,6 @@ import hyperlink
 import pytest
 import quart_trio
 import trio
-import trio.testing
 
 import qtrio.dialogs
 import qtrio.examples.download
@@ -239,8 +238,7 @@ async def test_get_dialog_canceled(
 
     destination = temporary_directory.joinpath("file")
 
-    # TODO: error: Module has no attribute "RaisesGroup"  [attr-defined]
-    with trio.testing.RaisesGroup(qtrio.UserCancelledError):  # type: ignore[attr-defined]
+    with pytest.RaisesGroup(qtrio.UserCancelledError):
         async with trio.open_nursery() as nursery:
             start = functools.partial(
                 qtrio.examples.download.start_get_dialog,

--- a/qtrio/_tests/test_core.py
+++ b/qtrio/_tests/test_core.py
@@ -36,7 +36,8 @@ def test_reenter_event_triggers_in_main_thread(qapp):
     reenter = qtrio.qt.Reenter()
 
     def post():
-        qtrio.register_event_type()
+        if qtrio.qt.registered_event_type() is None:
+            qtrio.register_event_type()
         event = qtrio.qt.ReenterEvent(fn=handler)
         qapp.postEvent(reenter, event)
 

--- a/qtrio/_tests/test_core.py
+++ b/qtrio/_tests/test_core.py
@@ -36,7 +36,7 @@ def test_reenter_event_triggers_in_main_thread(qapp):
     reenter = qtrio.qt.Reenter()
 
     def post():
-        if qtrio.qt.registered_event_type() is None:
+        if qtrio.registered_event_type() is None:
             qtrio.register_event_type()
         event = qtrio.qt.ReenterEvent(fn=handler)
         qapp.postEvent(reenter, event)

--- a/qtrio/_tests/test_core.py
+++ b/qtrio/_tests/test_core.py
@@ -1056,8 +1056,7 @@ async def test_emissions_nursery_receives_exceptions(is_async):
     def slot():
         raise LocalUniqueException()
 
-    # TODO: error: Module has no attribute "RaisesGroup"  [attr-defined]
-    with trio.testing.RaisesGroup(LocalUniqueException):  # type: ignore[attr-defined]
+    with pytest.RaisesGroup(LocalUniqueException):
         async with qtrio.open_emissions_nursery() as emissions_nursery:
             signal_host = SignalHost()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -102,7 +102,7 @@ p-tests =
     %(s_quart_trio)s
 s_pytest =
     # >= 6 for type hints
-    pytest ~= 7.2
+    pytest ~= 8.4
 s_pytest_trio =
     # >= 0.7.0 for trio_run configuration support
     pytest-trio >= 0.7.0


### PR DESCRIPTION
Summary:

- replace the deprecated `trio.testing.RaisesGroup` usage with `pytest.RaisesGroup`
- require pytest 8.4 for the above
- guard `test_reenter_event_triggers_in_main_thread` against an already-registered qtrio event type
- use the autojump Trio mock clock in the Crossing Paths example test to avoid CI timing failiures
- update Codecov upload steps from `codecov/codecov-action@v5` to `@v7` (see [here](https://github.com/codecov/codecov-action#v7-release))

Details:

`trio.testing.RaisesGroup` is no longer available, so the affected tests now use `pytest.RaisesGroup`. The pytest test dependency is raised to `~= 8.4` to provide that API.

`test_reenter_event_triggers_in_main_thread` can run after another qtrio async test has already registered the global Qt reenter event type. The test now only registers the event type if it has not already been registered.

The Crossing Paths example test now requests the Trio autojump mock clock to reduce timing sensitivity in CI.

Codecov upload steps are updated to `codecov/codecov-action@v7`, which uses the newer uploader verification path.

Testing:

All Github Actions passed on fork (see [here](https://github.com/niketh-keshavan/qtrio-fix))