### PR TITLE
Qt6 Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,12 +111,16 @@ jobs:
       matrix:
         python: ['3.10', '3.11']
         arch: ['x86', 'x64']
-        qt_library: ['PyQt5', 'PySide2']
+        qt_library: ['PyQt5', 'PySide2', 'PyQt6', 'PySide6']
         exclude:
           - python: '3.10'
             qt_library: 'PySide2'
           - python: '3.11'
             qt_library: 'PySide2'
+          - arch: 'x86'
+            qt_library: 'PyQt6'
+          - arch: 'x86'
+            qt_library: 'PySide6'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -148,7 +152,7 @@ jobs:
       fail-fast: false
       matrix:
         python: ['3.10', '3.11']
-        qt_library: ['PyQt5', 'PySide2']
+        qt_library: ['PyQt5', 'PySide2', 'PyQt6', 'PySide6']
         exclude:
           - python: '3.10'
             qt_library: 'PySide2'
@@ -164,7 +168,7 @@ jobs:
       - name: Install Linux test dependencies
         run: |
           apt-get update --yes
-          apt-get install --yes libgl1-mesa-dev xvfb x11-utils libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0
+          apt-get install --yes libgl1-mesa-dev xvfb x11-utils libdbus-1-3 libxkbcommon-x11-0 libxcb-cursor0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0
       - name: Run tests
         run: ./ci.sh
         env:
@@ -184,7 +188,7 @@ jobs:
       fail-fast: false
       matrix:
         python: ['3.10', '3.11']
-        qt_library: ['PyQt5', 'PySide2']
+        qt_library: ['PyQt5', 'PySide2', 'PyQt6', 'PySide6']
         exclude:
           - python: '3.10'
             qt_library: 'PySide2'
@@ -201,6 +205,7 @@ jobs:
         run: ./ci.sh
         env:
           INSTALL_EXTRAS: '[${{ matrix.qt_library }},p-tests]'
+          QT_QPA_PLATFORM: 'offscreen'
       - uses: codecov/codecov-action@v7
         if: always()
         with:

--- a/qtrio/_core.py
+++ b/qtrio/_core.py
@@ -66,7 +66,7 @@ def register_event_type() -> None:
 
     # assign to the global
     # TODO: https://bugreports.qt.io/browse/PYSIDE-1347
-    if qts.is_pyside_5_wrapper:
+    if qts.is_pyside_5_wrapper:  # pragma: no cover
         _reenter_event_type = typing.cast(
             typing.Callable[[int], QtCore.QEvent.Type], QtCore.QEvent.Type
         )(event_hint)
@@ -96,7 +96,7 @@ def register_requested_event_type(requested_value: int | QtCore.QEvent.Type) -> 
         raise qtrio.EventTypeAlreadyRegisteredError()
 
     # TODO: https://bugreports.qt.io/browse/PYSIDE-1468
-    if qts.is_pyside_5_wrapper:
+    if qts.is_pyside_5_wrapper:  # pragma: no cover
         event_hint = typing.cast(
             typing.Callable[[int | QtCore.QEvent.Type], int],
             QtCore.QEvent.registerEventType,
@@ -113,7 +113,7 @@ def register_requested_event_type(requested_value: int | QtCore.QEvent.Type) -> 
 
     # assign to the global
     # TODO: https://bugreports.qt.io/browse/PYSIDE-1347
-    if qts.is_pyside_5_wrapper:
+    if qts.is_pyside_5_wrapper:  # pragma: no cover
         _reenter_event_type = typing.cast(
             typing.Callable[[int], QtCore.QEvent.Type], QtCore.QEvent.Type
         )(event_hint)
@@ -530,7 +530,7 @@ def maybe_build_application() -> "QtGui.QGuiApplication":
     application: QtCore.QCoreApplication
 
     # TODO: https://bugreports.qt.io/browse/PYSIDE-1467
-    if qts.is_pyside_5_wrapper:
+    if qts.is_pyside_5_wrapper:  # pragma: no cover
         maybe_application = typing.cast(
             typing.Optional["QtCore.QCoreApplication"],
             QtWidgets.QApplication.instance(),

--- a/qtrio/_core.py
+++ b/qtrio/_core.py
@@ -16,6 +16,7 @@ import async_generator
 import attr
 import outcome
 import qts
+import qts.util
 import trio
 import trio.abc
 
@@ -65,16 +66,12 @@ def register_event_type() -> None:
 
     # assign to the global
     # TODO: https://bugreports.qt.io/browse/PYSIDE-1347
-    if qts.is_pyqt_5_wrapper:
-        _reenter_event_type = QtCore.QEvent.Type(event_hint)
-    elif qts.is_pyside_5_wrapper:
+    if qts.is_pyside_5_wrapper:
         _reenter_event_type = typing.cast(
             typing.Callable[[int], QtCore.QEvent.Type], QtCore.QEvent.Type
         )(event_hint)
-    else:  # pragma: no cover
-        raise qtrio.InternalError(
-            "You should not be here but you are running neither PyQt5 nor PySide2.",
-        )
+    else:
+        _reenter_event_type = QtCore.QEvent.Type(event_hint)
 
 
 def register_requested_event_type(requested_value: int | QtCore.QEvent.Type) -> None:
@@ -99,17 +96,13 @@ def register_requested_event_type(requested_value: int | QtCore.QEvent.Type) -> 
         raise qtrio.EventTypeAlreadyRegisteredError()
 
     # TODO: https://bugreports.qt.io/browse/PYSIDE-1468
-    if qts.is_pyqt_5_wrapper:
-        event_hint = QtCore.QEvent.registerEventType(requested_value)
-    elif qts.is_pyside_5_wrapper:
+    if qts.is_pyside_5_wrapper:
         event_hint = typing.cast(
             typing.Callable[[int | QtCore.QEvent.Type], int],
             QtCore.QEvent.registerEventType,
         )(requested_value)
-    else:  # pragma: no cover
-        raise qtrio.InternalError(
-            "You should not be here but you are running neither PyQt5 nor PySide2.",
-        )
+    else:
+        event_hint = QtCore.QEvent.registerEventType(requested_value)
 
     if event_hint == -1:
         raise qtrio.EventTypeRegistrationFailedError()
@@ -120,16 +113,12 @@ def register_requested_event_type(requested_value: int | QtCore.QEvent.Type) -> 
 
     # assign to the global
     # TODO: https://bugreports.qt.io/browse/PYSIDE-1347
-    if qts.is_pyqt_5_wrapper:
-        _reenter_event_type = QtCore.QEvent.Type(event_hint)
-    elif qts.is_pyside_5_wrapper:
+    if qts.is_pyside_5_wrapper:
         _reenter_event_type = typing.cast(
             typing.Callable[[int], QtCore.QEvent.Type], QtCore.QEvent.Type
         )(event_hint)
-    else:  # pragma: no cover
-        raise qtrio.InternalError(
-            "You should not be here but you are running neither PyQt5 nor PySide2.",
-        )
+    else:
+        _reenter_event_type = QtCore.QEvent.Type(event_hint)
 
 
 async def wait_signal(signal: "QtCore.SignalInstance") -> typing.Tuple[object, ...]:
@@ -541,17 +530,13 @@ def maybe_build_application() -> "QtGui.QGuiApplication":
     application: QtCore.QCoreApplication
 
     # TODO: https://bugreports.qt.io/browse/PYSIDE-1467
-    if qts.is_pyqt_5_wrapper:
-        maybe_application = QtWidgets.QApplication.instance()
-    elif qts.is_pyside_5_wrapper:
+    if qts.is_pyside_5_wrapper:
         maybe_application = typing.cast(
             typing.Optional["QtCore.QCoreApplication"],
             QtWidgets.QApplication.instance(),
         )
-    else:  # pragma: no cover
-        raise qtrio.InternalError(
-            "You should not be here but you are running neither PyQt5 nor PySide2.",
-        )
+    else:
+        maybe_application = QtWidgets.QApplication.instance()
 
     if maybe_application is None:
         application = QtWidgets.QApplication(sys.argv[1:])
@@ -660,7 +645,7 @@ class Runner:
             self.application.aboutToQuit.connect(_early_quit_warning)
 
         if execute_application:
-            return_code = self.application.exec_()
+            return_code = qts.util.exec(self.application)
 
             self.outcomes = attr.evolve(
                 self.outcomes,

--- a/qtrio/_qt.py
+++ b/qtrio/_qt.py
@@ -129,8 +129,10 @@ def connection(
     finally:
         expected_exception: typing.Type[Exception]
 
-        if qts.is_pyside_5_wrapper or qts.is_pyside_6_wrapper:
+        if qts.is_pyside_5_wrapper:
             expected_exception = RuntimeError
+        elif qts.is_pyside_6_wrapper:
+            expected_exception = SystemError
         else:
             expected_exception = TypeError
 

--- a/qtrio/_qt.py
+++ b/qtrio/_qt.py
@@ -129,7 +129,7 @@ def connection(
     finally:
         expected_exception: typing.Type[Exception]
 
-        if qts.is_pyside_5_wrapper:
+        if qts.is_pyside_5_wrapper:  # pragma: no cover
             expected_exception = RuntimeError
         elif qts.is_pyside_6_wrapper:
             expected_exception = SystemError

--- a/qtrio/_tests/helpers.py
+++ b/qtrio/_tests/helpers.py
@@ -6,10 +6,10 @@ import trio
 @pytest.fixture(name="qtrio_preshow_workaround", scope="session", autouse=True)
 def qtrio_preshow_workaround_fixture(qapp):
     dialog = QtWidgets.QMessageBox(
-        QtWidgets.QMessageBox.Information,
+        QtWidgets.QMessageBox.Icon.Information,
         "",
         "",
-        QtWidgets.QMessageBox.Ok,
+        QtWidgets.QMessageBox.StandardButton.Ok,
     )
 
     dialog.show()

--- a/qtrio/_tests/test_core.py
+++ b/qtrio/_tests/test_core.py
@@ -36,6 +36,8 @@ def test_reenter_event_triggers_in_main_thread(
     """
     import qtrio.qt
 
+    # TODO: i don't like monkeypatch...  but oh well, let's get rid of it someday and here's some context.
+    #       https://github.com/altendky/qtrio/pull/288/changes#r3619087492
     monkeypatch.setattr(qtrio._core, "_reenter_event_type", None)
     if event_type_registered:
         qtrio.register_event_type()

--- a/qtrio/_tests/test_core.py
+++ b/qtrio/_tests/test_core.py
@@ -27,11 +27,18 @@ def emissions_channel_fixture(request):
     return request.param
 
 
-def test_reenter_event_triggers_in_main_thread(qapp):
+@pytest.mark.parametrize("event_type_registered", [True, False])
+def test_reenter_event_triggers_in_main_thread(
+    qapp, monkeypatch, event_type_registered
+):
     """Reenter events posted in another thread result in the function being run in the
     main thread.
     """
     import qtrio.qt
+
+    monkeypatch.setattr(qtrio._core, "_reenter_event_type", None)
+    if event_type_registered:
+        qtrio.register_event_type()
 
     result = []
 

--- a/qtrio/_tests/test_core.py
+++ b/qtrio/_tests/test_core.py
@@ -6,7 +6,9 @@ import typing
 
 import outcome
 import pytest
+import qts
 from qts import QtCore
+from qts import QtWidgets
 import qtrio
 import qtrio._core
 import trio
@@ -82,6 +84,7 @@ def test_reenter_event_raises_if_type_not_registered(testdir):
         sys.platform == "win32"
         and sys.version_info >= (3, 11)
         and os.environ.get("CI") == "true"
+        and not qts.is_pyside_6_wrapper
     ),
     reason="the stderr fails to be captured in PyCharm and GitHub Actions",
 )
@@ -106,10 +109,18 @@ def test_reenter_event_writes_to_stderr_for_exception(capsys, testdir):
     # TODO: diagnostics to be removed
     print(repr(result.stderr.str()))
     print(result.stderr.str())
+    if qts.is_pyside_6_wrapper:
+        internal_error_line = (
+            r"^qtrio\._exceptions\.InternalError: Error calling Python override of"
+            r" QObject::event\(\): Exception while handling a reenter event$"
+        )
+    else:
+        internal_error_line = r"^qtrio\._exceptions\.InternalError: Exception while handling a reenter event$"
+
     result.stderr.re_match_lines(
         lines2=[
             r"^TypeError: 'int' object is not callable$",
-            r"^qtrio\._exceptions\.InternalError: Exception while handling a reenter event$",
+            internal_error_line,
         ],
     )
 
@@ -408,7 +419,7 @@ def test_out_of_hints_raises_for_requested(testdir):
             pass
 
         with pytest.raises(qtrio.EventTypeRegistrationFailedError):
-            qtrio.register_requested_event_type(QtCore.QEvent.User)
+            qtrio.register_requested_event_type(QtCore.QEvent.Type.User)
     """
     testdir.makepyfile(test_file)
 
@@ -446,9 +457,9 @@ def test_requesting_available_event_type_succeeds(testdir):
 
 
     def test():
-        qtrio.register_requested_event_type(QtCore.QEvent.User)
+        qtrio.register_requested_event_type(QtCore.QEvent.Type.User)
 
-        assert qtrio.registered_event_type() == QtCore.QEvent.User
+        assert qtrio.registered_event_type() == QtCore.QEvent.Type.User
     """
     testdir.makepyfile(test_file)
 
@@ -686,6 +697,20 @@ def test_failed_hosted_trio_exception_on_stdout(testdir):
     )
 
 
+def test_qobject_destroyed_signal_equality(qapp):
+    """Verify that an object's signal instances compare equal."""
+    q_object = QtCore.QObject()
+
+    assert q_object.destroyed == q_object.destroyed
+
+
+def test_qpushbutton_clicked_signal_equality(qapp):
+    """Verify that inherited signal instances compare equal."""
+    button = QtWidgets.QPushButton()
+
+    assert button.clicked == button.clicked
+
+
 def test_emissions_equal():
     """:class:`Emission` objects created from the same :class:`QtCore.Signal` instance
     and args are equal even if the attributes are different instances.
@@ -699,6 +724,15 @@ def test_emissions_equal():
     assert qtrio._core.Emission(
         signal=instance.signal, args=(13,)
     ) == qtrio._core.Emission(signal=instance.signal, args=(13,))
+
+
+def test_emissions_for_buttons():
+    """:class:`Emission` objects for the same button signal are equal."""
+    instance = QtWidgets.QPushButton()
+
+    assert qtrio._core.Emission(
+        signal=instance.clicked, args=(13,)
+    ) == qtrio._core.Emission(signal=instance.clicked, args=(13,))
 
 
 def test_emissions_unequal_by_signal():
@@ -1169,6 +1203,8 @@ def test_execute_manually(testdir):
     """Executing manually works."""
 
     test_file = r"""
+    import qts.util
+
     import qtrio
 
 
@@ -1184,7 +1220,7 @@ def test_execute_manually(testdir):
 
         assert not ran
 
-        runner.application.exec_()
+        qts.util.exec(runner.application)
 
         assert ran
     """

--- a/qtrio/_tests/test_dialogs.py
+++ b/qtrio/_tests/test_dialogs.py
@@ -51,7 +51,7 @@ async def test_get_integer_gets_value(qtbot: pytestqt.qtbot.QtBot) -> None:
             task_status.started()
 
         qtbot.keyClicks(dialog.edit_widget, str(test_value))
-        qtbot.mouseClick(dialog.accept_button, QtCore.Qt.LeftButton)
+        qtbot.mouseClick(dialog.accept_button, QtCore.Qt.MouseButton.LeftButton)
 
     test_value = 928
 
@@ -73,7 +73,7 @@ async def test_get_integer_raises_cancel_when_canceled(
             task_status.started()
 
         qtbot.keyClicks(dialog.edit_widget, "abc")
-        qtbot.mouseClick(dialog.reject_button, QtCore.Qt.LeftButton)
+        qtbot.mouseClick(dialog.reject_button, QtCore.Qt.MouseButton.LeftButton)
 
     async with trio.open_nursery() as nursery:
         await nursery.start(user)
@@ -92,7 +92,7 @@ async def test_get_integer_raises_for_invalid_input(
             task_status.started()
 
         qtbot.keyClicks(dialog.edit_widget, "abc")
-        qtbot.mouseClick(dialog.accept_button, QtCore.Qt.LeftButton)
+        qtbot.mouseClick(dialog.accept_button, QtCore.Qt.MouseButton.LeftButton)
 
     async with trio.open_nursery() as nursery:
         await nursery.start(user)
@@ -229,7 +229,7 @@ async def test_information_message_box(qtbot: pytestqt.qtbot.QtBot) -> None:
     dialog = qtrio.dialogs.create_message_box(
         title="Information",
         text=text,
-        icon=QtWidgets.QMessageBox.Information,
+        icon=QtWidgets.QMessageBox.Icon.Information,
     )
 
     async def user(task_status):
@@ -255,8 +255,11 @@ async def test_information_message_box_cancel(qtbot: pytestqt.qtbot.QtBot) -> No
     dialog = qtrio.dialogs.create_message_box(
         title="",
         text="",
-        icon=QtWidgets.QMessageBox.Information,
-        buttons=QtWidgets.QMessageBox.Ok | QtWidgets.QMessageBox.Cancel,
+        icon=QtWidgets.QMessageBox.Icon.Information,
+        buttons=(
+            QtWidgets.QMessageBox.StandardButton.Ok
+            | QtWidgets.QMessageBox.StandardButton.Cancel
+        ),
     )
 
     async def user(task_status):

--- a/qtrio/dialogs.py
+++ b/qtrio/dialogs.py
@@ -154,8 +154,12 @@ class IntegerDialog:
         self.dialog.show()
 
         buttons = _dialog_button_box_buttons_by_role(dialog=self.dialog)
-        self.accept_button = buttons.get(QtWidgets.QDialogButtonBox.AcceptRole)
-        self.reject_button = buttons.get(QtWidgets.QDialogButtonBox.RejectRole)
+        self.accept_button = buttons.get(
+            QtWidgets.QDialogButtonBox.ButtonRole.AcceptRole,
+        )
+        self.reject_button = buttons.get(
+            QtWidgets.QDialogButtonBox.ButtonRole.RejectRole,
+        )
 
         [self.edit_widget] = self.dialog.findChildren(QtWidgets.QLineEdit)
 
@@ -182,7 +186,7 @@ class IntegerDialog:
 
             await finished_event.wait()
 
-            if self.dialog.result() != QtWidgets.QDialog.Accepted:
+            if self.dialog.result() != QtWidgets.QDialog.DialogCode.Accepted:
                 raise qtrio.UserCancelledError()
 
             try:
@@ -255,8 +259,8 @@ class TextInputDialog:
         self.dialog.show()
 
         buttons = _dialog_button_box_buttons_by_role(dialog=self.dialog)
-        self.accept_button = buttons[QtWidgets.QDialogButtonBox.AcceptRole]
-        self.reject_button = buttons[QtWidgets.QDialogButtonBox.RejectRole]
+        self.accept_button = buttons[QtWidgets.QDialogButtonBox.ButtonRole.AcceptRole]
+        self.reject_button = buttons[QtWidgets.QDialogButtonBox.ButtonRole.RejectRole]
 
         [self.line_edit] = self.dialog.findChildren(QtWidgets.QLineEdit)
 
@@ -287,7 +291,7 @@ class TextInputDialog:
 
             dialog_result = self.dialog.result()
 
-            if dialog_result == QtWidgets.QDialog.Rejected:
+            if dialog_result == QtWidgets.QDialog.DialogCode.Rejected:
                 raise qtrio.UserCancelledError()
 
             # TODO: `: str` is a workaround for
@@ -333,7 +337,7 @@ class FileDialog:
     """The directory to be initially presented in the dialog."""
     default_file: typing.Optional[trio.Path] = None
     """The file to be initially selected in the dialog."""
-    options: QtWidgets.QFileDialog.Option = QtWidgets.QFileDialog.Option()
+    options: QtWidgets.QFileDialog.Option = QtWidgets.QFileDialog.Option(0)
     """Miscellaneous options.  See the Qt documentation."""
     parent: typing.Optional[QtWidgets.QWidget] = None
     """The parent widget for the dialog."""
@@ -387,7 +391,7 @@ class FileDialog:
         options = self.options
         if sys.platform == "darwin":
             # https://github.com/altendky/qtrio/issues/28
-            options |= QtWidgets.QFileDialog.DontUseNativeDialog
+            options |= QtWidgets.QFileDialog.Option.DontUseNativeDialog
 
         # TODO: huh, so ``options`` is entirely undocumented...  and hints an ``Any``
         #       return.
@@ -408,8 +412,12 @@ class FileDialog:
         self.dialog.show()
 
         buttons = _dialog_button_box_buttons_by_role(dialog=self.dialog)
-        self.accept_button = buttons.get(QtWidgets.QDialogButtonBox.AcceptRole)
-        self.reject_button = buttons.get(QtWidgets.QDialogButtonBox.RejectRole)
+        self.accept_button = buttons.get(
+            QtWidgets.QDialogButtonBox.ButtonRole.AcceptRole,
+        )
+        self.reject_button = buttons.get(
+            QtWidgets.QDialogButtonBox.ButtonRole.RejectRole,
+        )
         [self.file_name_line_edit] = self.dialog.findChildren(QtWidgets.QLineEdit)
 
         self.shown.emit(self.dialog)
@@ -437,7 +445,7 @@ class FileDialog:
             shown_event.set()
 
             await finished_event.wait()
-            if self.dialog.result() != QtWidgets.QDialog.Accepted:
+            if self.dialog.result() != QtWidgets.QDialog.DialogCode.Accepted:
                 raise qtrio.UserCancelledError()
 
             [path_string] = self.dialog.selectedFiles()
@@ -450,7 +458,7 @@ def create_file_save_dialog(
     parent: typing.Optional[QtWidgets.QWidget] = None,
     default_directory: typing.Optional[trio.Path] = None,
     default_file: typing.Optional[trio.Path] = None,
-    options: QtWidgets.QFileDialog.Option = QtWidgets.QFileDialog.Option(),
+    options: QtWidgets.QFileDialog.Option = QtWidgets.QFileDialog.Option(0),
 ) -> FileDialog:
     """Create a file save dialog.
 
@@ -465,8 +473,8 @@ def create_file_save_dialog(
         default_directory=default_directory,
         default_file=default_file,
         options=options,
-        file_mode=QtWidgets.QFileDialog.AnyFile,
-        accept_mode=QtWidgets.QFileDialog.AcceptSave,
+        file_mode=QtWidgets.QFileDialog.FileMode.AnyFile,
+        accept_mode=QtWidgets.QFileDialog.AcceptMode.AcceptSave,
     )
 
 
@@ -474,7 +482,7 @@ def create_file_open_dialog(
     parent: typing.Optional[QtWidgets.QWidget] = None,
     default_directory: typing.Optional[trio.Path] = None,
     default_file: typing.Optional[trio.Path] = None,
-    options: QtWidgets.QFileDialog.Option = QtWidgets.QFileDialog.Option(),
+    options: QtWidgets.QFileDialog.Option = QtWidgets.QFileDialog.Option(0),
 ) -> FileDialog:
     """Create a file open dialog.
 
@@ -489,13 +497,13 @@ def create_file_open_dialog(
         default_directory=default_directory,
         default_file=default_file,
         options=options,
-        file_mode=QtWidgets.QFileDialog.AnyFile,
-        accept_mode=QtWidgets.QFileDialog.AcceptOpen,
+        file_mode=QtWidgets.QFileDialog.FileMode.AnyFile,
+        accept_mode=QtWidgets.QFileDialog.AcceptMode.AcceptOpen,
     )
 
 
 message_box_standard_button_union: typing.TypeAlias = (
-    QtWidgets.QMessageBox.StandardButton | QtWidgets.QMessageBox.StandardButtons
+    QtWidgets.QMessageBox.StandardButton
 )
 
 
@@ -549,7 +557,7 @@ class MessageBox:
         self.dialog.show()
 
         buttons = _dialog_button_box_buttons_by_role(dialog=self.dialog)
-        self.accept_button = buttons[QtWidgets.QDialogButtonBox.AcceptRole]
+        self.accept_button = buttons[QtWidgets.QDialogButtonBox.ButtonRole.AcceptRole]
 
         self.shown.emit(self.dialog)
 
@@ -576,15 +584,15 @@ class MessageBox:
 
             result = self.dialog.result()
 
-            if result == QtWidgets.QDialog.Rejected:
+            if result == QtWidgets.QDialog.DialogCode.Rejected:
                 raise qtrio.UserCancelledError()
 
 
 def create_message_box(
     title: str = "",
     text: str = "",
-    icon: QtWidgets.QMessageBox.Icon = QtWidgets.QMessageBox.Information,
-    buttons: message_box_standard_button_union = QtWidgets.QMessageBox.Ok,
+    icon: QtWidgets.QMessageBox.Icon = QtWidgets.QMessageBox.Icon.Information,
+    buttons: message_box_standard_button_union = QtWidgets.QMessageBox.StandardButton.Ok,
     parent: typing.Optional[QtWidgets.QWidget] = None,
 ) -> MessageBox:
     """Create a message box.

--- a/qtrio/examples/emissions.py
+++ b/qtrio/examples/emissions.py
@@ -26,15 +26,11 @@ class QSignaledWidget(QtWidgets.QWidget):
         super().closeEvent(event)
         if event.isAccepted():
             # TODO: https://bugreports.qt.io/browse/PYSIDE-1318
-            if qts.is_pyqt_5_wrapper:
-                self.closed.emit()
-            elif qts.is_pyside_5_wrapper:
+            if qts.is_pyside_5_wrapper:
                 signal = typing.cast(QtCore.SignalInstance, self.closed)
                 signal.emit()
-            else:  # pragma: no cover
-                raise qtrio.InternalError(
-                    "You should not be here but you are running neither PyQt5 nor PySide2.",
-                )
+            else:
+                self.closed.emit()
         else:  # pragma: no cover
             pass
 
@@ -44,15 +40,11 @@ class QSignaledWidget(QtWidgets.QWidget):
         super().showEvent(event)
         if event.isAccepted():
             # TODO: https://bugreports.qt.io/browse/PYSIDE-1318
-            if qts.is_pyqt_5_wrapper:
-                self.shown.emit()
-            elif qts.is_pyside_5_wrapper:
+            if qts.is_pyside_5_wrapper:
                 signal = typing.cast(QtCore.SignalInstance, self.shown)
                 signal.emit()
-            else:  # pragma: no cover
-                raise qtrio.InternalError(
-                    "You should not be here but you are running neither PyQt5 nor PySide2.",
-                )
+            else:
+                self.shown.emit()
         else:  # pragma: no cover
             pass
 

--- a/qtrio/examples/emissions.py
+++ b/qtrio/examples/emissions.py
@@ -26,7 +26,7 @@ class QSignaledWidget(QtWidgets.QWidget):
         super().closeEvent(event)
         if event.isAccepted():
             # TODO: https://bugreports.qt.io/browse/PYSIDE-1318
-            if qts.is_pyside_5_wrapper:
+            if qts.is_pyside_5_wrapper:  # pragma: no cover
                 signal = typing.cast(QtCore.SignalInstance, self.closed)
                 signal.emit()
             else:
@@ -40,7 +40,7 @@ class QSignaledWidget(QtWidgets.QWidget):
         super().showEvent(event)
         if event.isAccepted():
             # TODO: https://bugreports.qt.io/browse/PYSIDE-1318
-            if qts.is_pyside_5_wrapper:
+            if qts.is_pyside_5_wrapper:  # pragma: no cover
                 signal = typing.cast(QtCore.SignalInstance, self.shown)
                 signal.emit()
             else:

--- a/qtrio/examples/readme/qt.py
+++ b/qtrio/examples/readme/qt.py
@@ -16,7 +16,7 @@ def create_output() -> QtWidgets.QMessageBox:
         QtWidgets.QMessageBox.Icon.Question,
         "Hello",
         "",
-        QtWidgets.QMessageBox.Ok,
+        QtWidgets.QMessageBox.StandardButton.Ok,
     )
 
 

--- a/qtrio/examples/readme/qtrio_example.py
+++ b/qtrio/examples/readme/qtrio_example.py
@@ -21,7 +21,7 @@ def create_output() -> qtrio.dialogs.MessageBox:
         title="Hello",
         text="",
         icon=QtWidgets.QMessageBox.Icon.Question,
-        buttons=QtWidgets.QMessageBox.Ok,
+        buttons=QtWidgets.QMessageBox.StandardButton.Ok,
     )
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,10 @@ pyqt5 =
 pyside2 =
     # != 5.15.2, != 5.15.2.1 for https://bugreports.qt.io/browse/PYSIDE-1431
     pyside2 ~= 5.15, != 5.15.2, != 5.15.2.1
+pyside6 =
+    pyside6 ~= 6.1
+pyqt6 =
+    pyqt6 ~= 6.1
 cli =
     click ~= 8.1
 examples =


### PR DESCRIPTION
@altendky back again :)

This PR adds PyQt6 and PySide6 support while retaining existing PyQt5 compatibility.

I work in a lab that uses ARTIQ as our experiment control hardware. With the upgrade to ARTIQ 9, ARTIQ is now explicitly dependent on PyQt6 and its Nix environment installs `pyqt6` with Qt6 libraries ([release notes](https://git.m-labs.hk/M-Labs/artiq/src/tag/9.0/RELEASE_NOTES.rst), [ARTIQ 9 setup.py](https://git.m-labs.hk/M-Labs/artiq/src/tag/9.0/setup.py)).

To support our (hopefully soon!) upgrate to ARTIQ 9, we would need Qt6 support in Qtrio.

Changes:

1. Package support
[`setup.cfg`](https://github.com/niketh-keshavan/qtrio-fix/blob/main/setup.cfg#L56-L67) now adds optional installation extras for both Qt 6 bindings:
```ini
pyside6 =
    pyside6 ~= 6.1
pyqt6 =
    pyqt6 ~= 6.1
```

2. Qt binding compatability
[`qtrio/_core.py`](https://github.com/niketh-keshavan/qtrio-fix/blob/main/qtrio/_core.py#L69-L121) generalizes Qt bindings
- PySide2 retains its binding-specific type casts.
- PyQt5, PyQt6, and PySide6 use the normal Qt API.
- Application lookup now supports Qt 6 wrappers.
- `QApplication.exec_()` is replaced by `qts.util.exec()` in [`Runner.run()`](https://github.com/niketh-keshavan/qtrio-fix/blob/main/qtrio/_core.py#L647-L648)
PyQt6 removed the `exec_()` compatibility method, so dispatching through qts.util.exec() selects the correct spelling for each binding. [PyQt6 migration documentation](https://www.riverbankcomputing.com/static/Docs/PyQt6/pyqt5_differences.html) [`qtrio/examples/emissions.py`](https://github.com/niketh-keshavan/qtrio-fix/blob/main/qtrio/examples/emissions.py#L26-L47) applies the same approach to custom widget signals.

3. PySide 6 disconnect behavior
[`qtrio/_qt.py`](https://github.com/niketh-keshavan/qtrio-fix/blob/main/qtrio/_qt.py#L129-L142) handles the exception raised when cleanup disconnects a signal that was already disconnected:
- PySide2 raises `RuntimeError`.
- PySide6 raises `SystemError`.
- PyQt uses `TypeError`.

4. Scoped Qt enums
PyQt6 uses scoped Python enums and removes many Qt5-era class-level aliases. Example:
```python
QtWidgets.QDialog.Accepted
```
becomes
```python
QtWidgets.QDialog.DialogCode.Accepted
```
This was applied uniformly across all dialog implementation.

5. Tests
The test suite was updated to exercise the Qt 6 forms directly.

The reenter-event test is also parameterized over registered and unregistered event-type states at [`qtrio/_tests/test_core.py` — reenter coverage](https://github.com/niketh-keshavan/qtrio-fix/blob/main/qtrio/_tests/test_core.py#L30-L49). NOTE: This failed on my fork, because I don't have the key setup. Should work here.

Testing:

Again, apart from codecov all passed on my fork [here](https://github.com/niketh-keshavan/qtrio-fix).

Note (another):

This work was all done previously on our labs fork of Qtrio.