### PR TITLE
Add newsfragment for Qt6 support (#288)

### DIFF
--- a/newsfragments/288.feature.rst
+++ b/newsfragments/288.feature.rst
@@ -1,0 +1,1 @@
+QTrio now supports PyQt6 and PySide6. Thanks to `Niketh Keshavan (@niketh-keshavan) <https://github.com/niketh-keshavan>`__ for implementing this support.


### PR DESCRIPTION
## Summary

Restore the missing Towncrier feature fragment for Qt6 support from #288 so the change is included in future release notes.

Thank @niketh-keshavan (Niketh Keshavan) for implementing PyQt6 and PySide6 support.

This fragment intentionally lands before the eventual Towncrier release build; Towncrier is not run as part of this PR.

## Checks

- Verified the commit signature with `git verify-commit`.
- Confirmed the commit contains only `newsfragments/288.feature.rst`.
- Confirmed `docs/source/history.rst` is unchanged.
