### PR TITLE
Require Python 3.10 and complete changelog audit

### DIFF
--- a/newsfragments/286.breaking.rst
+++ b/newsfragments/286.breaking.rst
@@ -1,0 +1,1 @@
+QTrio now requires Python 3.10 or newer. Support for Python 3.7, 3.8, and 3.9 has been removed.

--- a/newsfragments/287.misc.rst
+++ b/newsfragments/287.misc.rst
@@ -1,0 +1,1 @@
+Updated the test suite for pytest 8.4 and reduced CI timing sensitivity. Thanks to `Niketh Keshavan (@niketh-keshavan) <https://github.com/niketh-keshavan>`__ for these improvements.

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires=
     # python_version < '3.8' for `Protocol`
     typing-extensions; python_version < '3.8'
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.10
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
## Summary

- Require Python 3.10 or newer in package metadata.
- Add the missing breaking-change newsfragment as a follow-up to #286.
- Add the missing test-suite and CI newsfragment as a follow-up to #287, including contributor credit.
- Leave the existing `288.feature.rst` coverage for Qt 6 support unchanged.

## Validation

- Python 3.10.20 with pytest 8.4.2: 225 passed.
- Built both wheel and sdist with `python -m build` outside the checkout.
- `twine check --strict` passed for both artifacts.
- Both artifacts declare `Requires-Python: >=3.10`.
- Verified the commit signature and the exact three-file diff against `origin/main`.

## Notes

Towncrier intentionally has not been run so these newsfragments remain available for the next release-note build.
