### PR TITLE
Prepare release v0.8.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,8 +36,8 @@ The QTrio project's goal is to bring the friendly concurrency of Trio using Pyth
 ``async`` and ``await`` syntax together with the GUI features of Qt to enable more
 correct code and a more pleasant developer experience.  QTrio is `permissively licensed
 <https://github.com/altendky/qtrio/blob/main/LICENSE>`__ to avoid introducing
-restrictions beyond those of the underlying Python Qt library you choose.  Both PySide2
-and PyQt5 are supported.
+restrictions beyond those of the underlying Python Qt library you choose.  PyQt5, PyQt6,
+PySide2, and PySide6 are supported.
 
 By enabling use of ``async`` and ``await`` it is possible in some cases to write
 related code more concisely and clearly than you would get with the signal and slot

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ The QTrio project's goal is to bring the friendly concurrency of Trio using Pyth
 correct code and a more pleasant developer experience.  QTrio is `permissively licensed
 <https://github.com/altendky/qtrio/blob/main/LICENSE>`__ to avoid introducing
 restrictions beyond those of the underlying Python Qt library you choose.  PyQt5, PyQt6,
-PySide2, and PySide6 are supported.
+and PySide6 are supported.
 
 By enabling use of ``async`` and ``await`` it is possible in some cases to write
 related code more concisely and clearly than you would get with the signal and slot
@@ -176,8 +176,8 @@ really containing the activity.
    :target: `repository`_
    :alt: Repository
 
-.. _tests: https://github.com/altendky/qtrio/actions?query=branch%3Amaster
-.. |tests badge| image:: https://img.shields.io/github/workflow/status/altendky/qtrio/CI/main?color=seagreen&logo=GitHub-Actions&logoColor=whitesmoke
+.. _tests: https://github.com/altendky/qtrio/actions?query=branch%3Amain
+.. |tests badge| image:: https://img.shields.io/github/actions/workflow/status/altendky/qtrio/ci.yml?branch=main&color=seagreen&logo=GitHub-Actions&logoColor=whitesmoke
    :target: `tests`_
    :alt: Tests
 

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ The QTrio project's goal is to bring the friendly concurrency of Trio using Pyth
 correct code and a more pleasant developer experience.  QTrio is `permissively licensed
 <https://github.com/altendky/qtrio/blob/main/LICENSE>`__ to avoid introducing
 restrictions beyond those of the underlying Python Qt library you choose.  PyQt5, PyQt6,
-and PySide6 are supported.
+PySide2, and PySide6 are supported.
 
 By enabling use of ``async`` and ``await`` it is possible in some cases to write
 related code more concisely and clearly than you would get with the signal and slot

--- a/docs/source/development/testing.rst
+++ b/docs/source/development/testing.rst
@@ -17,7 +17,7 @@ You can run ``pytest``, ``black``, and ``sphinx`` directly from your own install
 
    python -m venv testvenv
    testvenv/bin/python -m pip install --upgrade pip setuptools wheel
-   testvenv/bin/python -m pip install --editable .[pyside2,p-checks,p-docs,p-tests]
+   testvenv/bin/python -m pip install --editable .[pyside6,p-checks,p-docs,p-tests]
    testvenv/bin/pytest --pyargs qtrio
 
 The CI test script, ``ci.sh``, in the project root will run ``pytest`` with ``coverage``
@@ -56,7 +56,7 @@ The documentation can be built with ``sphinx``.
 
    python -m venv testvenv
    testvenv/bin/python -m pip install --upgrade pip setuptools wheel
-   testvenv/bin/python -m pip install --editable .[pyside2,p-docs]
+   testvenv/bin/python -m pip install --editable .[pyside6,p-docs]
    source testenv/bin/activate
    cd docs/
    make html --always-make

--- a/docs/source/development/testing.rst
+++ b/docs/source/development/testing.rst
@@ -57,7 +57,7 @@ The documentation can be built with ``sphinx``.
    python -m venv testvenv
    testvenv/bin/python -m pip install --upgrade pip setuptools wheel
    testvenv/bin/python -m pip install --editable .[pyside6,p-docs]
-   source testenv/bin/activate
+   source testvenv/bin/activate
    cd docs/
    make html --always-make
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -28,14 +28,13 @@ are available for installing optional dependencies or applying version constrain
 - ``examples`` - For running examples.
 - ``pyqt5`` - For running with PyQt5, primarily to apply any version constraints.
 - ``pyqt6`` - For running with PyQt6, primarily to apply any version constraints.
-- ``pyside2`` - For running with PySide2, primarily to apply any version constraints.
 - ``pyside6`` - For running with PySide6, primarily to apply any version constraints.
 
 A normal installation might look like:
 
 .. code-block:: bash
 
-    $ myenv/bin/pip install qtrio[pyside2]
+    $ myenv/bin/pip install qtrio[pyside6]
 
 Overview
 --------

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -28,6 +28,7 @@ are available for installing optional dependencies or applying version constrain
 - ``examples`` - For running examples.
 - ``pyqt5`` - For running with PyQt5, primarily to apply any version constraints.
 - ``pyqt6`` - For running with PyQt6, primarily to apply any version constraints.
+- ``pyside2`` - For running with PySide2, primarily to apply any version constraints.
 - ``pyside6`` - For running with PySide6, primarily to apply any version constraints.
 
 A normal installation might look like:

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -27,7 +27,9 @@ are available for installing optional dependencies or applying version constrain
 - ``cli`` - For CLI usage, presently just examples.
 - ``examples`` - For running examples.
 - ``pyqt5`` - For running with PyQt5, primarily to apply any version constraints.
+- ``pyqt6`` - For running with PyQt6, primarily to apply any version constraints.
 - ``pyside2`` - For running with PySide2, primarily to apply any version constraints.
+- ``pyside6`` - For running with PySide6, primarily to apply any version constraints.
 
 A normal installation might look like:
 

--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -11,8 +11,7 @@ QTrio 0.8.0 (2026-07-22)
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
-- QTrio now requires Python 3.10 or newer. Support for Python 3.7, 3.8, and 3.9 has been removed. (`#286 <https://github.com/altendky/qtrio/issues/286>`__)
-
+- QTrio now requires Python 3.10 or newer. Support for Python 3.7, 3.8, and 3.9 has been removed. PySide2 is no longer supported. (`#286 <https://github.com/altendky/qtrio/issues/286>`__)
 
 Features
 ~~~~~~~~

--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -5,6 +5,27 @@ Release history
 
 .. towncrier release notes start
 
+QTrio 0.8.0 (2026-07-22)
+------------------------
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+- QTrio now requires Python 3.10 or newer. Support for Python 3.7, 3.8, and 3.9 has been removed. (`#286 <https://github.com/altendky/qtrio/issues/286>`__)
+
+
+Features
+~~~~~~~~
+
+- QTrio now supports PyQt6 and PySide6. Thanks to `Niketh Keshavan (@niketh-keshavan) <https://github.com/niketh-keshavan>`__ for implementing this support. (`#288 <https://github.com/altendky/qtrio/issues/288>`__)
+
+
+For contributors
+~~~~~~~~~~~~~~~~
+
+- Updated the test suite for pytest 8.4 and reduced CI timing sensitivity. Thanks to `Niketh Keshavan (@niketh-keshavan) <https://github.com/niketh-keshavan>`__ for these improvements. (`#287 <https://github.com/altendky/qtrio/issues/287>`__)
+
+
 QTrio 0.7.0 (2023-06-07)
 ------------------------
 

--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -11,7 +11,7 @@ QTrio 0.8.0 (2026-07-22)
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
-- QTrio now requires Python 3.10 or newer. Support for Python 3.7, 3.8, and 3.9 has been removed. PySide2 is no longer supported. (`#286 <https://github.com/altendky/qtrio/issues/286>`__)
+- QTrio now requires Python 3.10 or newer. Support for Python 3.7, 3.8, and 3.9 has been removed. PySide2 remains supported, but is untested. (`#286 <https://github.com/altendky/qtrio/issues/286>`__)
 
 Features
 ~~~~~~~~

--- a/newsfragments/286.breaking.rst
+++ b/newsfragments/286.breaking.rst
@@ -1,1 +1,0 @@
-QTrio now requires Python 3.10 or newer. Support for Python 3.7, 3.8, and 3.9 has been removed.

--- a/newsfragments/287.misc.rst
+++ b/newsfragments/287.misc.rst
@@ -1,1 +1,0 @@
-Updated the test suite for pytest 8.4 and reduced CI timing sensitivity. Thanks to `Niketh Keshavan (@niketh-keshavan) <https://github.com/niketh-keshavan>`__ for these improvements.

--- a/newsfragments/288.feature.rst
+++ b/newsfragments/288.feature.rst
@@ -1,1 +1,0 @@
-QTrio now supports PyQt6 and PySide6. Thanks to `Niketh Keshavan (@niketh-keshavan) <https://github.com/niketh-keshavan>`__ for implementing this support.

--- a/qtrio/_core.py
+++ b/qtrio/_core.py
@@ -163,8 +163,8 @@ class Emission:
     Note:
         Each time you access a signal such as ``a_qobject.some_signal`` you get a
         different signal instance object so the ``signal`` attribute generally will not
-        be the same object.  A signal instance is a ``QtCore.SignalInstance`` in
-        PySide2 or ``QtCore.pyqtBoundSignal`` in PyQt5.
+        be the same object.  A signal instance is a ``QtCore.SignalInstance`` in PySide or
+        ``QtCore.pyqtBoundSignal`` in PyQt.
     """
 
     signal: "QtCore.SignalInstance"

--- a/qtrio/_version.py
+++ b/qtrio/_version.py
@@ -3,4 +3,4 @@
 #   exec'd from docs/source/conf.py
 #   attr:'ed from setup.cfg
 
-__version__ = "0.7.0+dev"
+__version__ = "0.8.0"

--- a/qtrio/_version.py
+++ b/qtrio/_version.py
@@ -3,4 +3,4 @@
 #   exec'd from docs/source/conf.py
 #   attr:'ed from setup.cfg
 
-__version__ = "0.8.0"
+__version__ = "0.8.0+dev"

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ project_urls =
 description = a library bringing Qt GUIs together with ``async`` and ``await`` via Trio
 long_description = file: README.rst
 long_description_content_type = text/x-rst
-keywords = async, io, Trio, GUI, Qt, PyQt5, PySide2
+keywords = async, io, Trio, GUI, Qt, PyQt5, PyQt6, PySide6
 classifiers =
         License :: OSI Approved :: MIT License
         License :: OSI Approved :: Apache Software License
@@ -58,9 +58,6 @@ pyqt5 =
     # >= 5.15.1 for https://www.riverbankcomputing.com/pipermail/pyqt/2020-July/043064.html
     pyqt5 ~=5.15.1
     pyqt5-stubs ~=5.15.2
-pyside2 =
-    # != 5.15.2, != 5.15.2.1 for https://bugreports.qt.io/browse/PYSIDE-1431
-    pyside2 ~= 5.15, != 5.15.2, != 5.15.2.1
 pyside6 =
     pyside6 ~= 6.1
 pyqt6 =

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ project_urls =
 description = a library bringing Qt GUIs together with ``async`` and ``await`` via Trio
 long_description = file: README.rst
 long_description_content_type = text/x-rst
-keywords = async, io, Trio, GUI, Qt, PyQt5, PyQt6, PySide6
+keywords = async, io, Trio, GUI, Qt, PyQt5, PyQt6, PySide2, PySide6
 classifiers =
         License :: OSI Approved :: MIT License
         License :: OSI Approved :: Apache Software License
@@ -58,6 +58,9 @@ pyqt5 =
     # >= 5.15.1 for https://www.riverbankcomputing.com/pipermail/pyqt/2020-July/043064.html
     pyqt5 ~=5.15.1
     pyqt5-stubs ~=5.15.2
+pyside2 =
+    # != 5.15.2, != 5.15.2.1 for https://bugreports.qt.io/browse/PYSIDE-1431
+    pyside2 ~= 5.15, != 5.15.2, != 5.15.2.1
 pyside6 =
     pyside6 ~= 6.1
 pyqt6 =


### PR DESCRIPTION
## Summary

- Set the release version to 0.8.0.
- Add the 2026-07-22 release notes covering the Python 3.10 requirement, Qt 6 support, and contributor test/CI updates.
- Consume release-note fragments 286, 287, and 288.

## Validation

- [x] Based directly on refreshed `origin/main` commit `d2706bfe28c37ac82e81ffda53b37b293c2e6017`.
- [x] Verified the release diff is limited to the version file, release history, and three consumed fragments.
- [x] Verified the release commit's configured SSH signature.
- [x] Built the wheel and source distribution with Python 3.10.
- [x] Passed `twine check --strict` for both artifacts.
- [x] Verified artifact names, version 0.8.0, and `Requires-Python: >=3.10` metadata.
- [x] Collected SHA-256 checksums for both local validation artifacts.

## Later Steps

- [x] Review and approve this release PR.
- [x] Create the `v0.8.0` tag.
- [x] Inspect the final release artifacts.
- [x] Upload the final release artifacts to PyPI.
- [x] Restore the development version to `0.8.0+dev` after the release.
- [x] Confirm post-release CI passes.
- [x] Merge this PR.
